### PR TITLE
Änderung der Texte zum Stichwort #61

### DIFF
--- a/src/app/forderung-edit/forderung-edit.component.html
+++ b/src/app/forderung-edit/forderung-edit.component.html
@@ -58,11 +58,11 @@
     <hr>
   </div>
   <div *ngIf="(forderungFG.get('geprueft').value==='2')">
-    <p>Der ADFC hat mit der Elternkammer vereinbart, dass bis zum FIXME nur Mitglieder der Elternkammer mit einem speziellen Stichwort Anträge bei der Polizei abgeben sollen.
+    <p>Der ADFC hat mit der Hamburger Elternkammer vereinbart, dass zunächst nur zur jeweiligen Schule Gehörige die Tempo-30-Forderungen stellen sollen. Daher können die Tempo-30-Forderungen für Schulen bis zum FIXME nur nach Eingabe des richtigen Stichworts gestellt werden. Dies erhälst du bei der Elternkammer oder dem Elternrat der Schule.
     </p>
     <mat-form-field class="t30-full-width">
       <input matInput placeholder="Stichwort" formControlName="password">
-      <mat-hint>Dieses wird dir von der Elternkammer oder dem Elternrat mitgeteilt</mat-hint>
+
     </mat-form-field>
     <mat-form-field class="t30-full-width">
       <input matInput placeholder="Dein Bezug zur Einrichtung" formControlName="bezugZurEinrichtung">


### PR DESCRIPTION
Kann der mat-hint unter dem Eingabefeld einfach so weggenommen werden?