### PR TITLE
Mailerstellen: Zeilenumbruch nach Vorgeschichte

### DIFF
--- a/src/app/forderung-edit/forderung-edit.component.html
+++ b/src/app/forderung-edit/forderung-edit.component.html
@@ -57,6 +57,7 @@
   </div>
   <div class="headline">Vorgeschichte:</div>
   <div class="value">{{ streetSection.progress_report}}</div>
+  <br>
   <mat-radio-group class="tp-radio-group" formControlName="geprueft" aria-label="Bitte prüfe die obigen Angaben">
     <mat-radio-button class="tp-radio-button" value="2">Ja, alles ist korrekt.</mat-radio-button>
     <mat-radio-button class="tp-radio-button" value="1">Ich möchte etwas korrigieren.</mat-radio-button>


### PR DESCRIPTION
ist <br> hier richtig, oder was nutzt man dafür?