### PR TITLE
Spendenseite angelegt, fixes #138

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -17,6 +17,7 @@ import { SozialeEinrichtungEditComponent } from './soziale-einrichtung-edit/sozi
 import { CanDeactivateGuard } from './can-deactivate.guard';
 import { ForderungEditComponent } from './forderung-edit/forderung-edit.component';
 import { ForderungViewComponent } from './forderung-view/forderung-view.component';
+import { SpendenComponent } from './spenden/spenden.component';
 
 const routes: Routes = [{
   path: 'main',
@@ -66,6 +67,9 @@ const routes: Routes = [{
 }, {
   path: 'login',
   component: LoginComponent,
+}, {
+  path: 'spenden',
+  component: SpendenComponent,
 }, {
   path: 'register',
   component: RegisterComponent

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -58,7 +58,7 @@
 <hr>
 <a href="https://hamburg.adfc.de/datenschutzhinweise/" target="_blank" rel="noopener" class="footer-link">Datenschutzhinweise</a>
 <a href="https://hamburg.adfc.de/impressum/" target="_blank" rel="noopener" class="footer-link">Impressum</a>
-<a href="https://hamburg.adfc.de/verein/spende/" target="_blank" rel="noopener" class="footer-link">Spende</a>
+<a routerLink="/spenden" class="footer-link">Spenden</a>
 <hr>
 Dieses Webtool hilft dir, Tempo 30 im Umfeld sozialer Einrichtungen beim zuständigen Polizeikommissariat zu fordern.
 Es ist Teil der Kampagne des ADFC Hamburg <a target="_blank" href="{{CAMPAIN_URL}}">Tempo 30 an sozialen Einrichtungen</a>.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,6 +33,10 @@ export class AppComponent implements OnInit, OnDestroy {
       showPublic: false, showUser: true
     },
     {
+      path: '/spenden', label: 'Spenden', icon: 'directions_bike',
+      showPublic: true, showUser: true
+    },
+    {
       path: '/AbmeldenAsk', label: 'Abmelden', icon: 'power_settings_new',
       showPublic: false, showUser: true
     },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -52,6 +52,7 @@ import { StreetSectionEditComponent } from './street-section-edit/street-section
 import { ForderungViewComponent } from './forderung-view/forderung-view.component';
 import { StarLegendeComponent } from './star-legende/star-legende.component';
 import { AppSnackBarComponent } from './app-snack-bar/app-snack-bar.component';
+import { SpendenComponent } from './spenden/spenden.component';
 
 
 export function tokenGetter() {
@@ -86,6 +87,7 @@ export function tokenGetter() {
     ForderungViewComponent,
     StarLegendeComponent,
     AppSnackBarComponent,
+    SpendenComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/forderung-edit/forderung-edit.component.ts
+++ b/src/app/forderung-edit/forderung-edit.component.ts
@@ -211,7 +211,7 @@ export class ForderungEditComponent extends CanDeactivateFormControlComponent im
           emailId = rtnData.id;
         }
         this.forderungService.sendMail(emailId, data.password).subscribe(rtnMailSend => {
-          this.router.navigate(['/einrichtung/view', this.einrichtung.id]);
+          this.router.navigate(['/spenden']);
           this.notifierService.addSuccess('Die E-Mail wurde versandt. Du findest sie unter "Meine Forderungsmails" wieder.');
         });
       } else {

--- a/src/app/spenden/spenden.component.html
+++ b/src/app/spenden/spenden.component.html
@@ -38,7 +38,7 @@
   IBAN: DE80 4306 0967 2029 4456 00
   BIC: GENODEM1GLS
 </pre>
-<p>Bitte gib bei einer Spende im Verwendungszweck das Wort »Spende T30Sozial« und deine Adresse an.</p>
+<p>Bitte gib bei einer Spende im Verwendungszweck das Wort »Spende« und deine Adresse an.</p>
 
 <p>Bei Spenden bis zu 200 € benötigst du gegenüber dem Finanzamt lediglich deinen Kontoauszug, um diese in der Steuererklärung geltend zu machen. Dennoch senden wir dir gerne eine Spendenbescheinigung ab einer Spendenhöhe von 20 Euro zu. Bitte gib dafür bei Überweisungen im Verwendungszweck das Wort »Spende« und deine Adresse an.</p>
 

--- a/src/app/spenden/spenden.component.html
+++ b/src/app/spenden/spenden.component.html
@@ -1,0 +1,48 @@
+<h2>DANKE, Widerstand ist nicht umsonst!</h2>
+<p>
+  Vielen Dank für Deinen Beitrag zu mehr Tempo 30 in Hamburg.
+</p>
+<p>
+  Wir würden gerne Zusammen mit Dir unsere Kampange weiter ausbauen:
+  <ul>
+    <li>Presse und Öffentlichkeitsarbeit</li>
+    <li>Sitzungen des Verkehrsausschusses beobachten</li>
+    <li>Uns besser mit allen vernetzen die Tempo 30 in der Stadt fordern</li>
+    <li>Das Online-Tool verbssern</li>
+    <li>Juristisch gegen Tempo 50 vorgehen</li>
+    <li>..... </li>
+  </ul>
+  <h3>Für all das brauchen wir neben vielen ehrenamtlichen auch Geld.</h3>
+
+  Unterstütze jetzt unsere Arbeit mit deiner Spende!
+
+<h3>Mitglied werden</h3>
+
+<p>Ganz besonderes freuen wir uns, wenn du Mitglied im ADFC werden möchtest.
+   Als Mitglied&nbsp;unterstützt du mit deinem Beitrag unsere politische Arbeit
+    für das Fahrrad – damit&nbsp;das Radfahren im Alltag und auf Reisen noch
+    sicherer und komfortabler wird. Du förderst das Radfahren als eine attraktive
+    Alternative zur Autofahrt – mit Spaß, Entspannung und Gesundheitsvorsorge
+    für den Einzelnen und mehr Lebensqualität und Klimaschutz für alle.
+</p>
+<a href="http://www.adfc.de/vorteile/vorteile-fuer-mitglieder" title="Öffnet externen Link in neuem Fenster" target="_blank" class="external-link-new-window">Vorteile für Mitglieder</a>
+&nbsp;|&nbsp;<a href="https://www.adfc.de/sei-dabei/mitglied-werden/" title="Opens internal link in current window" target="_blank" class="external-link-new-window">Jetzt Mitglied werden</a>
+&nbsp;|&nbsp;<a href="https://www.adfc.de/mitgliedschaft/geschenkmitgliedschaft/bewegung-verschenken" target="_blank">Beitrittsformular für Geschenkmitgliedschaft</a>
+&nbsp;|&nbsp;<a href="https://www.adfc.de/foerdermitgliedwerden/beitrittserklaerung-foerdermitglied" title="Öffnet externen Link in neuem Fenster" target="_blank" class="external-link-new-window">Beitrittsformular für Fördermitglieder</a>
+
+
+<h3>Überweisung</h3>
+<pre>
+  Empfänger: ADFC Hamburg
+  Bank: GLS Gemeinschaftsbank eG
+  IBAN: DE80 4306 0967 2029 4456 00
+  BIC: GENODEM1GLS
+</pre>
+<p>Bitte gib bei einer Spende im Verwendungszweck das Wort »Spende T30Sozial« und deine Adresse an.</p>
+
+<p>Bei Spenden bis zu 200 € benötigst du gegenüber dem Finanzamt lediglich deinen Kontoauszug, um diese in der Steuererklärung geltend zu machen. Dennoch senden wir dir gerne eine Spendenbescheinigung ab einer Spendenhöhe von 20 Euro zu. Bitte gib dafür bei Überweisungen im Verwendungszweck das Wort »Spende« und deine Adresse an.</p>
+
+
+<h3>Spende per Lastschrift oder Paypal</h3>
+Möchtest du lieber per Lastschrift oder Paypal Spenden, besuche bitte unsere
+<a href="https://hamburg.adfc.de/verein/spende/" target="_blank" rel="noopener" class="footer-link">allgemeine Spendenseite des Landsverbands.</a>

--- a/src/app/spenden/spenden.component.spec.ts
+++ b/src/app/spenden/spenden.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SpendenComponent } from './spenden.component';
+
+describe('SpendenComponent', () => {
+  let component: SpendenComponent;
+  let fixture: ComponentFixture<SpendenComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SpendenComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SpendenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/spenden/spenden.component.ts
+++ b/src/app/spenden/spenden.component.ts
@@ -1,15 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-spenden',
   templateUrl: './spenden.component.html',
   styleUrls: ['./spenden.component.css']
 })
-export class SpendenComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
+export class SpendenComponent {
 
 }

--- a/src/app/spenden/spenden.component.ts
+++ b/src/app/spenden/spenden.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-spenden',
+  templateUrl: './spenden.component.html',
+  styleUrls: ['./spenden.component.css']
+})
+export class SpendenComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
Bitte vor der Freigabe den Screenshot prüfen:
![Screenshot_20191111_100138](https://user-images.githubusercontent.com/1101544/68574618-9a4cf280-046a-11ea-9edd-eb3c1e573aa7.png)

Ich würde das Spenden-Menü immer oben anzeigen (zwischen Mein Profil und Abmelden).
Da ist ja noch  viel Platz.

Wenn Euch das Fahrrad Icon nicht gefällt, findet ihr hier:
https://material.io/resources/icons/?style=baseline
weitere Icons.

Der "Spenden" Link unten zeigt jetzt auch auf diese Seite.

Wir könnten auch wenn sich jemand abmeldet, ihn auf die Spendenseite leiten.
